### PR TITLE
Check definition removal via REST API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.opensource.zalan.do/stups/openjdk:8u66-b17-1-9
 
-EXPOSE 8080
+EXPOSE 8443
 
 COPY zmon-controller-app/target/zmon-controller-1.0.1-SNAPSHOT.jar /zmon-controller.jar
 COPY target/scm-source.json /

--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,6 @@ Please use the `main ZMON repository`_ to start a Vagrant demo box.
 
 Make sure the provided Vagrant-Box is up and all services are running.
 
-Update your GitHub ``client-id`` and ``client-secret`` in ``zmon-controller-app/src/main/config/application-github.yml``.
-
 .. code-block:: bash
 
     $ ./mvnw clean install

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,8 @@ Please use the `main ZMON repository`_ to start a Vagrant demo box.
 
 Make sure the provided Vagrant-Box is up and all services are running.
 
+Update your GitHub ``client-id`` and ``client-secret`` in ``zmon-controller-app/src/main/config/application-github.yml``.
+
 .. code-block:: bash
 
     $ ./mvnw clean install

--- a/zmon-controller-app/src/main/java/de/zalando/zmon/rest/CheckDefinitionsApi.java
+++ b/zmon-controller-app/src/main/java/de/zalando/zmon/rest/CheckDefinitionsApi.java
@@ -39,6 +39,14 @@ public class CheckDefinitionsApi extends AbstractZMonController {
         return zMonService.createOrUpdateCheckDefinition(checkDefinition);
     }
 
+    @RequestMapping(method = RequestMethod.DELETE)
+    @ResponseStatus(HttpStatus.OK)
+    public void deleteCheckDef(@Valid @RequestBody(required = true)
+            final CheckDefinitionImport checkDefinition) throws ZMonException {
+
+        zMonService.deleteCheckDefinition(checkDefinition);
+    }
+
     @RequestMapping(value = "/{id}", method = RequestMethod.GET)
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody

--- a/zmon-controller-app/src/main/java/de/zalando/zmon/service/ZMonService.java
+++ b/zmon-controller-app/src/main/java/de/zalando/zmon/service/ZMonService.java
@@ -39,6 +39,8 @@ public interface ZMonService {
 
     CheckDefinition createOrUpdateCheckDefinition(CheckDefinitionImport checkDefinition);
 
+    void deleteCheckDefinition(CheckDefinitionImport checkDefinition);
+
     void deleteCheckDefinition(String userName, String name, String owningTeam);
 
     void deleteDetachedCheckDefinitions();

--- a/zmon-controller-app/src/main/java/de/zalando/zmon/service/impl/ZMonServiceImpl.java
+++ b/zmon-controller-app/src/main/java/de/zalando/zmon/service/impl/ZMonServiceImpl.java
@@ -205,12 +205,17 @@ public class ZMonServiceImpl implements ZMonService {
     }
 
     @Override
+    public void deleteCheckDefinition(final CheckDefinitionImport checkDefinition) {
+        deleteCheckDefinition(checkDefinition.getLastModifiedBy(), checkDefinition.getName(), checkDefinition.getOwningTeam());
+    }
+
+    @Override
     public void deleteCheckDefinition(final String userName, final String name, final String owningTeam) {
         Preconditions.checkNotNull(userName);
         Preconditions.checkNotNull(name);
         Preconditions.checkNotNull(owningTeam);
 
-        LOG.info("Deleting check definition with name {} and team {}", name, owningTeam);
+        LOG.info("Deleting check definition with name '{}' and team '{}'", name, owningTeam);
 
         final CheckDefinition checkDefinition = checkDefinitionSProc.deleteCheckDefinition(userName, name, owningTeam);
 

--- a/zmon-controller-app/src/test/java/de/zalando/zmon/service/impl/ZMonServiceImplIT.java
+++ b/zmon-controller-app/src/test/java/de/zalando/zmon/service/impl/ZMonServiceImplIT.java
@@ -17,7 +17,6 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -246,6 +245,25 @@ public class ZMonServiceImplIT {
 
         MatcherAssert.assertThat(allCheckDefinitionsAfter.getCheckDefinitions(),
             Matchers.not(Matchers.hasItem(CheckDefinitionIsEqual.equalTo(newCheckDefinition))));
+    }
+
+    @Test
+    public void testDeleteExistingCheckDefinition() throws Exception {
+
+        // create a new check
+        final CheckDefinitionImport newCheckDefinitionImport = checkImportGenerator.generate();
+        final CheckDefinition newCheckDefinition = service.createOrUpdateCheckDefinition(newCheckDefinitionImport);
+        newCheckDefinition.setStatus(DefinitionStatus.DELETED);
+
+        // delete the check definition
+        service.deleteCheckDefinition(newCheckDefinitionImport);
+
+        // test if the check definition is available
+        final List<CheckDefinition> checkDefinitions = service.getCheckDefinitions(null,
+                Collections.singletonList(newCheckDefinition.getId()));
+
+        MatcherAssert.assertThat(checkDefinitions,
+                Matchers.contains(CheckDefinitionIsEqual.equalTo(newCheckDefinition)));
     }
 
     @Test


### PR DESCRIPTION
@Jan-M as far as I understood the code correctly, this should be enough for supporting check definition removal. The entries are marked as "DELETED" in the DB and will be cleaned up completely as soon as the alerts are removed as well. The scheduler fetches only active check definitions, so it should also detect the removal correctly. If I missed sth. please let me know.