### PR TITLE
#64 add teams to teams popover and limit to max 5 teams

### DIFF
--- a/zmon-controller-app/src/main/resources/templates/index.html
+++ b/zmon-controller-app/src/main/resources/templates/index.html
@@ -121,7 +121,7 @@
                         data:instantaneous-alert-evaluation="${hasInstantaneousAlertEvaluationPermission}"
                         data:cloud-check="${cloudCheckId}">
 
-                        <button type="button" class="auth-user btn btn-default dropdown-toggle" data-toggle="dropdown" popover="Teams: {{userTeams}}" popover-placement="left" popover-trigger="mouseenter" sec:authentication="name">
+                        <button type="button" class="auth-user btn btn-default dropdown-toggle" data-toggle="dropdown" popover="Teams: {{userTeamsOnPopover}}" popover-placement="left" popover-trigger="mouseenter" sec:authentication="name">
                             klaus
                             <span class="caret"></span>
                         </button>
@@ -208,24 +208,15 @@
             $scope.checksPerSecond = 0;
             $scope.serviceStatus = {};
             $scope.checkInvocationsCache = {};
+            $scope.userTeamsOnPopover = '(no team)';
 
             this.userInfo = UserInfoService.get();
 
-            // Helper, decides if support icon should be shown based
-            // on the user team (Incident team only for now).
-            this.showSupportIcon = function() {
-                var userTeams = " ";
-
-                if ($scope.IndexCtrl.userInfo.teams) {
-                    userTeams = $scope.IndexCtrl.userInfo.teams;
-                }
-
-                if (_.isArray(userTeams)) {
-                    userTeams = userTeams.join();
-                }
-
-                return userTeams.toLowerCase().indexOf("incident") >= 0;
-            };
+            // limit list of teams on popover to 5
+            if (this.userInfo.teams) {
+                var teams = this.userInfo.teams.split(',');
+                $scope.userTeamsOnPopover = teams.slice(-5).join(', ') + (teams.length > 5 ? '...' : '');
+            }
 
             this.getLoadingIndicatorState = function() {
                 return LoadingIndicatorService.getState();


### PR DESCRIPTION
adds teams to popover with a limit of 5 teams and ellipsis, and removes no longer used "showSupportIcon" function.